### PR TITLE
add revert flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "lingotags",
   "version": "1.0.1",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -3,6 +3,7 @@
 import { initConfig } from "../cli/init";
 import { generateTranslationTags } from "../translationGenerator";
 import { loadConfig } from "../utils/configUtils";
+import { revertFromManifest } from "../utils/utils";
 
 const run = async () => {
   try {
@@ -11,7 +12,9 @@ const run = async () => {
 
     switch (command) {
       case "--version":
+      case "-version":
       case "-v":
+      case "--v":
         const packageJson = require("../../package.json");
         console.log(`v${packageJson.version}`);
         break;
@@ -33,9 +36,9 @@ const run = async () => {
             process.exit(1);
           }
 
-          console.log("Starting translation generation...");
+          console.log("Starting Keys generation...");
           await generateTranslationTags(config);
-          console.log("Translation generation complete");
+          console.log("Keys generation complete");
         } catch (error: any) {
           console.error("Error details:", {
             name: error.name,
@@ -45,15 +48,29 @@ const run = async () => {
           process.exit(1);
         }
         break;
+      case "revert":
+      case "r":
+        try {
+          const config = loadConfig();
+          const manifestPath = process.argv[3] || config.manifest;
+          revertFromManifest(manifestPath);
+          console.log("✅ Successfully reverted changes");
+          process.exit(0);
+        } catch (error: any) {
+          console.error("Revert failed:", error.message);
+          process.exit(1);
+        }
+        break;
       case "help":
       default:
-        console.log(`Usage: translation-tags-generator <command>
+        console.log(`Usage: lingotags <command>
           Commands:
-            init      Create configuration file
-            generate  Run translation tag generation (alias: gen, g)
-            help      Show this help message
+            init        Create configuration file
+            generate    Run translation generation (alias: gen, g)
+            revert      Revert changes from manifest file (alias: r)
+            help        Show this help message
           Options:
-            --version, -v  Show version number`);
+            --version,-version,--v, -v  Show version number`);
     }
   } catch (error: any) {
     console.error("Unexpected error details:", {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -40,6 +40,14 @@ export const initConfig = async () => {
       },
       {
         type: "input",
+        name: "manifest",
+        message: "Enter manifest file name for reverts:",
+        default: "lingotags-manifest.json",
+        validate: (input: string) =>
+          input.trim().length > 0 ? true : "manifest file name is required",
+      },
+      {
+        type: "input",
         name: "filePattern",
         message: "Enter file pattern to search:",
         default: "**/*.{html,tsx,jsx}",

--- a/src/translationGenerator.ts
+++ b/src/translationGenerator.ts
@@ -4,7 +4,14 @@ import path from "path";
 
 import { TranslationGeneratorConfig, TranslationOutput } from "./types/types";
 import { searchPatterns } from "./utils/searchPatterns";
-import { logVerbose, processFileContent, writeOutputFile } from "./utils/utils";
+import {
+  getGlobalKeyCounter,
+  logVerbose,
+  processFileContent,
+  setGlobalKeyCounter,
+  writeManifest,
+  writeOutputFile,
+} from "./utils/utils";
 
 export async function generateTranslationTags(
   config: TranslationGeneratorConfig
@@ -13,13 +20,16 @@ export async function generateTranslationTags(
     filePattern: "**/*.html",
     verbose: false,
     ...config,
+    manifest: path.resolve(
+      process.cwd(),
+      config.manifest || "lingotags-manifest.json"
+    ),
   };
 
   try {
     const searchPath = path.resolve(process.cwd(), finalConfig.searchDirectory);
     console.log("Resolved search path:", searchPath);
 
-    // Add directory content listing
     console.log("Directory contents:");
     try {
       const contents = fs.readdirSync(searchPath, { recursive: true });
@@ -32,11 +42,9 @@ export async function generateTranslationTags(
       throw new Error(`Search directory does not exist: ${searchPath}`);
     }
 
-    // Use forward slashes for glob pattern
     const pattern = finalConfig.filePattern?.replace(/\\/g, "/") || "**/*.html";
     console.log("Search pattern:", pattern);
 
-    // Use process.cwd() as the base for glob
     const files = await glob(pattern, {
       cwd: searchPath,
       absolute: true,
@@ -46,31 +54,45 @@ export async function generateTranslationTags(
     console.log("Found files:", files);
     logVerbose(finalConfig.verbose, `Found ${files.length} files to process`);
 
-    // Process files and collect output
     const output: TranslationOutput = {};
+
+    const fileChanges: Array<{
+      filePath: string;
+      original: string;
+      modified: string;
+    }> = [];
+    const initialKeyCounter = getGlobalKeyCounter();
 
     files.forEach((filePath) => {
       try {
         const fileContent = fs.readFileSync(filePath, "utf-8");
-        const { modifiedContent, matches } = processFileContent(
-          fileContent,
-          searchPatterns
-        );
+        const { modifiedContent, matches, originalContent } =
+          processFileContent(fileContent, searchPatterns);
 
         if (matches.length > 0) {
           output[filePath] = matches;
           fs.writeFileSync(filePath, modifiedContent, "utf-8");
+          fileChanges.push({
+            filePath,
+            original: originalContent,
+            modified: modifiedContent,
+          });
           logVerbose(
             finalConfig.verbose,
             `Processed ${matches.length} tags in ${filePath}`
           );
+          if (matches.length > getGlobalKeyCounter()) {
+            setGlobalKeyCounter(matches.length);
+          }
         }
       } catch (error) {
         console.error(`Error processing file ${filePath}:`, error);
       }
     });
 
-    // Write output to JSON file
+    writeManifest(finalConfig.manifest, initialKeyCounter, fileChanges);
+    console.log(`📦 Manifest file created: ${finalConfig.manifest}`);
+
     writeOutputFile(finalConfig.outputFile, output);
     console.log(
       "Translation tags generated successfully. " +
@@ -80,18 +102,4 @@ export async function generateTranslationTags(
     console.error("Error generating translation tags:", error);
     process.exit(1);
   }
-}
-
-// Example usage function
-export async function main() {
-  await generateTranslationTags({
-    searchDirectory: "./about",
-    outputFile: "translation_tags.json",
-    verbose: true,
-  });
-}
-
-// Only run main if this file is being run directly
-if (require.main === module) {
-  main();
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,6 +3,7 @@ export interface TranslationGeneratorConfig {
   outputFile: string;
   filePattern?: string;
   verbose?: boolean;
+  manifest?: string;
 }
 
 export interface TranslationMatch {
@@ -10,6 +11,7 @@ export interface TranslationMatch {
   tag: string;
   content: string;
   dynamic?: boolean;
+  manifest?: string; 
 }
 export interface TranslationOutput {
   [filePath: string]: TranslationMatch[];

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -9,6 +9,7 @@ export const ConfigSchema = z.object({
   outputFile: z
     .string()
     .min(3, "Output file path is required and must be at least 3 characters"),
+  manifest: z.string().optional().describe("Path to manifest file for reverts"),
   filePattern: z.string().optional().default("**/*.{html,tsx,jsx}"),
   verbose: z.boolean().optional().default(false),
 });
@@ -28,6 +29,20 @@ export const loadConfig = (
   return ConfigSchema.parse(rawConfig);
 };
 
-// Optional: Configuration Validation Function
 export const validateConfig = (config: unknown): TranslationConfig =>
   ConfigSchema.parse(config);
+
+export async function initConfig(): Promise<void> {
+  const configPath = "./config.json";
+
+  const defaultConfig = {
+    searchDirectory: "./",
+    outputFile: "translations.json",
+    filePattern: "**/*.{html,tsx,jsx}",
+    verbose: false,
+    manifest: "lingotags-manifest.json",
+  };
+
+  fs.writeFileSync(configPath, JSON.stringify(defaultConfig, null, 2), "utf-8");
+  console.log("✅ Config file created:", configPath);
+}


### PR DESCRIPTION
This pull request introduces several significant updates to the `lingotags` project, focusing on adding support for manifest files and improving the configuration and translation tag generation processes.

### Manifest File Support:
* Added a new `manifest` field to the configuration to specify the path for a manifest file used for reverts. (`package.json`, `src/types/types.ts`, `src/utils/configUtils.ts`, `src/cli/init.ts`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R5) [[2]](diffhunk://#diff-11e9171ff36dfa6e6b396909ac6b924cf79337d5f05a7eaa15f78a9b2e2eded6R6-R14) [[3]](diffhunk://#diff-f624d2810b538e481c3a1cd552f8808c287f2ca8c481c00b9b2f19219681b125R12) [[4]](diffhunk://#diff-e1696fb1e33358030d9a32164c9b59852b42a7bac0f9b6946378a39deeb4b60dR41-R48)
* Implemented functions to write and revert changes using a manifest file, including tracking file changes and key counters. (`src/utils/utils.ts`, `src/translationGenerator.ts`) [[1]](diffhunk://#diff-5acab41990585fa68ae01ff7b2e2915628d19237840c3061b31fcadc1c0f09b8L80-R93) [[2]](diffhunk://#diff-b22de990ee9445780ad8a020394544ad09af69ea97162234a301eeb7109bb84cL49-R95)

### Configuration Enhancements:
* Added a new `initConfig` function to create a default configuration file if it doesn't exist. (`src/utils/configUtils.ts`)
* Updated the `generateTranslationTags` function to resolve the manifest path and handle file changes accordingly. (`src/translationGenerator.ts`)

### Code Refactoring:
* Removed the example usage function `main` from `translationGenerator.ts` to clean up the file. (`src/translationGenerator.ts`)
* Added utility functions for getting and setting a global key counter. (`src/utils/utils.ts`)