### PR TITLE
fix(keygen): resolve key generation off-by-one error and improve JSX …

### DIFF
--- a/src/translationGenerator.ts
+++ b/src/translationGenerator.ts
@@ -6,6 +6,7 @@ import { TranslationGeneratorConfig, TranslationOutput } from "./types/types";
 import { searchPatterns } from "./utils/searchPatterns";
 import {
   getGlobalKeyCounter,
+  initializeKeyCounter,
   logVerbose,
   processFileContent,
   setGlobalKeyCounter,
@@ -59,14 +60,15 @@ export async function generateTranslationTags(
     const pattern = finalConfig.filePattern?.replace(/\\/g, "/") || "**/*.html";
     console.log("Search pattern:", pattern);
 
-    const files = await glob(pattern, {
+    const allFiles = await glob(pattern, {
       cwd: searchPath,
       absolute: true,
       windowsPathsNoEscape: true,
     });
 
-    console.log("Found files:", files);
-    logVerbose(finalConfig.verbose, `Found ${files.length} files to process`);
+    initializeKeyCounter(allFiles);
+    const initialKeyCounter = getGlobalKeyCounter();
+    console.log(`🔑 Initialized key counter at: ${initialKeyCounter}`);
 
     const output: TranslationOutput = {};
 
@@ -75,9 +77,8 @@ export async function generateTranslationTags(
       original: string;
       modified: string;
     }> = [];
-    const initialKeyCounter = getGlobalKeyCounter();
 
-    files.forEach((filePath) => {
+    allFiles.forEach((filePath) => {
       try {
         logVerbose(finalConfig.verbose, `🔍 Scanning file: ${filePath}`);
         const fileContent = fs.readFileSync(filePath, "utf-8");


### PR DESCRIPTION
…handling

- Fix key counter initialization to start at 0 and properly increment before first use
- Implement robust JSX content extraction handling nested expressions and attributes
- Add strict regex matching for existing keys in key attributes only
- Update key generation logic to fill gaps and prevent duplicates
- Add validation for text content presence before key assignment
This pull request introduces several enhancements and bug fixes to the translation generation process. The key changes include initializing the global key counter based on existing keys in files, refining the extraction of tag content, and improving the generation of unique keys. Here are the most important changes:

### Enhancements to Key Counter Initialization:

* [`src/translationGenerator.ts`](diffhunk://#diff-b22de990ee9445780ad8a020394544ad09af69ea97162234a301eeb7109bb84cR9): Added `initializeKeyCounter` to set the global key counter based on the maximum existing key found in the files. This ensures that new keys are unique and sequential. [[1]](diffhunk://#diff-b22de990ee9445780ad8a020394544ad09af69ea97162234a301eeb7109bb84cR9) [[2]](diffhunk://#diff-b22de990ee9445780ad8a020394544ad09af69ea97162234a301eeb7109bb84cL62-R71) [[3]](diffhunk://#diff-b22de990ee9445780ad8a020394544ad09af69ea97162234a301eeb7109bb84cL78-R81)
* [`src/utils/utils.ts`](diffhunk://#diff-5acab41990585fa68ae01ff7b2e2915628d19237840c3061b31fcadc1c0f09b8R216-R244): Introduced `findMaxExistingKey` and `initializeKeyCounter` functions to scan files for existing keys and set the global key counter accordingly.

### Improvements to Tag Content Extraction:

* [`src/utils/utils.ts`](diffhunk://#diff-5acab41990585fa68ae01ff7b2e2915628d19237840c3061b31fcadc1c0f09b8L48-R68): Updated `extractTagContent` to remove JSX expressions and clean up HTML/JSX tags more effectively. This improves the accuracy of the extracted text content.

### Simplification of Unique Key Generation:

* [`src/utils/utils.ts`](diffhunk://#diff-5acab41990585fa68ae01ff7b2e2915628d19237840c3061b31fcadc1c0f09b8L48-R68): Simplified the `generateUniqueKey` function to increment the global key counter directly within the return statement.